### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/appknox.yml
+++ b/.github/workflows/appknox.yml
@@ -20,6 +20,9 @@
 #    action executes, check the 'Security' tab for results
 
 name: Appknox
+permissions:
+  contents: read
+  security-events: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/sora/security/code-scanning/1](https://github.com/Wbaker7702/sora/security/code-scanning/1)

To fix the problem, explicitly define a `permissions` block in the workflow. Since this workflow checks out code, builds, and uploads SARIF files to GitHub Advanced Security, it only needs `contents: read` (to fetch code) and `security-events: write` (to upload SARIF results). The best place for this block is at the top level, right after the `name:` attribute (as a workflow-wide default for all jobs), or within the `jobs.appknox:` definition. The most secure and least privileged option is to add:

```yaml
permissions:
  contents: read
  security-events: write
```

immediately after the `name: Appknox` line (line 22-23).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow permissions to allow reading repository contents and writing security events.
  * No changes to triggers or job steps; existing automation behavior remains the same.
  * No user-facing impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->