### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -5,6 +5,8 @@
 # For more information, see:
 # https://github.com/github/super-linter
 name: Lint Code Base
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/sora/security/code-scanning/2](https://github.com/Wbaker7702/sora/security/code-scanning/2)

To fix this issue, you should add a `permissions` block in your workflow to explicitly set the minimal permissions required for your linter job. By default, `contents: read` is recommended for jobs that only need to fetch and read the code, and not write to the repository or perform actions like creating or modifying issues. If the linter or workflow actions need to write, comment, or interact with PRs, you can augment accordingly (e.g., `pull-requests: write`), but the safest minimal starting point is `contents: read`. The best and least intrusive way to do this is to add the `permissions:` key at the top level of the workflow, right after the `name:` and before the `on:` block, so that it’s applied to the whole workflow and all jobs. No extra imports or definitions are necessary, only this YAML keys insertion.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
