### PR TITLE
Upgrade prismjs library

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,5 +78,8 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "typescript": "^5.3.3"
+  },
+  "resolutions": {
+    "prismjs": "^1.30.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5221,15 +5221,10 @@ postcss@^8.4.30, postcss@^8.4.47:
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 
-prismjs@^1.30.0:
+prismjs@^1.30.0, prismjs@~1.27.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.30.0.tgz#d9709969d9d4e16403f6f348c63553b19f0975a9"
   integrity sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==
-
-prismjs@~1.27.0:
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.27.0.tgz#bb6ee3138a0b438a3653dd4d6ce0cc6510a45057"
-  integrity sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==
 
 proc-log@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION
Force PrismJS to version 1.30.0 or later using yarn resolutions to resolve conflicting dependency versions.

The project had `react-syntax-highlighter` directly depending on `prismjs@^1.30.0`, but one of its sub-dependencies, `refractor`, was pulling in an older `prismjs@~1.27.0`. This resolution ensures that all instances of PrismJS across the project are unified to version 1.30.0.

---
<a href="https://cursor.com/background-agent?bcId=bc-2b7f54d2-7de7-4787-b0b0-9d8359d14fa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-2b7f54d2-7de7-4787-b0b0-9d8359d14fa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Tightened dependency resolution by locking a transitive syntax-highlighting library version to ensure consistent builds across environments and reduce unexpected breakage.
  * Improves reliability and predictability of installations, aiding stability in CI and local development.
  * No user-facing changes in functionality; behavior remains unchanged.
  * Future updates to this dependency will be managed intentionally to avoid inadvertent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->