### PR TITLE
Changes from background agent bc-10bbd4ea-659f-408c-a51e-3d43aba0d29c

### DIFF
--- a/renderer/lib/sanitization.ts
+++ b/renderer/lib/sanitization.ts
@@ -111,7 +111,7 @@ export function safeRemoveQuotes(input: string, quoteChar: string = '"'): string
   const escapedQuote = quoteChar.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   
   // Use global flag to replace all occurrences
-  const regex = new RegExp(`^${escapedQuote}|${escapedQuote}$`, 'g');
+  const regex = new RegExp(escapedQuote, 'g');
   return input.replace(regex, '').trim();
 }
 


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fix `safeRemoveQuotes` to correctly remove all occurrences of quote characters by adjusting the regex.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The original regex `^${escapedQuote}|${escapedQuote}$` only matched quotes at the beginning or end of the string, leading to partial removal when multiple quote characters were present. The updated regex `escapedQuote` with the global flag ensures all instances of the specified quote character are removed from the entire string.

---
<a href="https://cursor.com/background-agent?bcId=bc-10bbd4ea-659f-408c-a51e-3d43aba0d29c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-10bbd4ea-659f-408c-a51e-3d43aba0d29c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Input sanitization now removes quote characters throughout the entire text, not just at the beginning or end, improving consistency across fields.

* **Behavior Changes**
  * Text containing quotes will have those characters fully stripped during sanitization, which may alter how certain content appears in inputs and displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->