### PR TITLE
Potential fix for code scanning alert no. 12: Overly permissive regular expression range

### DIFF
--- a/renderer/lib/regex-validator.ts
+++ b/renderer/lib/regex-validator.ts
@@ -365,7 +365,7 @@ export const COMMON_PATTERNS = {
   
   // Unescaped dash in character class
   UNESCAPED_DASH: {
-    pattern: /[a-zA-Z0-9%=.,-_]/,
+    pattern: /[a-zA-Z0-9%=.,\-_]/,
     issue: 'Dash creates unintended range from , to _',
     fix: /[a-zA-Z0-9%=.,\-_]/
   },


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/sora/security/code-scanning/12](https://github.com/Wbaker7702/sora/security/code-scanning/12)

To fix the overly permissive regex character set, change the pattern in the `UNESCAPED_DASH` object from `/[a-zA-Z0-9%=.,-_]/` to `/[a-zA-Z0-9%=.,\-_]/`. This ensures the dash is treated literally rather than as a range operator, matching only the characters explicitly listed. Specifically, within `renderer/lib/regex-validator.ts`, replace the faulty line at `pattern:` inside `COMMON_PATTERNS.UNESCAPED_DASH` with the corrected one. No new imports or definitions are necessary for this change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
