### PR TITLE
Handle unsupported debug type

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,23 +5,6 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "type": "aws-sam",
-      "request": "direct-invoke",
-      "name": "Invoke Lambda with API Gateway",
-      "invokeTarget": {
-        "target": "api",
-        "templatePath": "Template Location",
-        "logicalId": "Function Logical ID"
-      },
-      "api": {
-        "path": "Path",
-        "httpMethod": "Method",
-        "payload": {
-          "json": {}
-        }
-      }
-    },
-    {
       "name": "Nextron: Main",
       "type": "node",
       "request": "attach",


### PR DESCRIPTION
Remove unsupported AWS SAM debug configuration from `launch.json` as this is an Electron/Nextron project.

---
<a href="https://cursor.com/background-agent?bcId=bc-1b09e20b-febe-409e-b8a5-b1f306255573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-1b09e20b-febe-409e-b8a5-b1f306255573"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Cleaned up development launch configurations by removing an obsolete AWS SAM direct-invoke entry previously used for API Gateway/Lambda testing. Existing app launch options remain unchanged. No impact to features, UI, or performance; this streamlines local development setup and reduces clutter in run/debug options for a clearer developer experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->