### PR TITLE
Potential fix for code scanning alert no. 31: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/defender-for-devops.yml
+++ b/.github/workflows/defender-for-devops.yml
@@ -17,6 +17,8 @@
 # Read the official documentation here : https://learn.microsoft.com/en-us/azure/defender-for-cloud/quickstart-onboard-github
 
 name: "Microsoft Defender For Devops"
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/sora/security/code-scanning/31](https://github.com/Wbaker7702/sora/security/code-scanning/31)

To resolve the issue, an explicit `permissions:` key should be added to restrict what the GitHub Actions workflow jobs may do with the GITHUB_TOKEN. The required permission is typically `contents: read` for workflows that only check out code and upload results, unless they need to write pull requests or similar. Here, the job does not appear to require write access to contents, issues, or pull requests—it merely checks out code and uploads a SARIF file for uploading to the Security tab. Therefore, placing `permissions: contents: read` at the workflow (top/root) level or specifically for the `MSDO` job will suffice. Adding it at the root will ensure all jobs (should there be more added in future) are by default restricted, unless they need overrides. This change should be made near the top of `.github/workflows/defender-for-devops.yml`, immediately after the `name:` field and before the `on:` block.

No new imports or dependencies are needed for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated security configuration for automated workflows to enforce access controls.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->