### PR TITLE
Potential fix for code scanning alert no. 14: Shell command built from environment values

### DIFF
--- a/src/monitoring/build-monitor.ts
+++ b/src/monitoring/build-monitor.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { writeFileSync, readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { captureMessage, trackBuild, trackPerformance } from './sentry';
@@ -109,7 +109,7 @@ class BuildMonitor {
     try {
       const distPath = join(process.cwd(), 'dist');
       if (existsSync(distPath)) {
-        const sizeOutput = execSync(`du -sh ${distPath}`, { encoding: 'utf8' });
+        const sizeOutput = execFileSync('du', ['-sh', distPath], { encoding: 'utf8' });
         const sizeMatch = sizeOutput.match(/^(\d+(?:\.\d+)?)([KMGT]?)/);
         if (sizeMatch) {
           const size = parseFloat(sizeMatch[1]);


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/sora/security/code-scanning/14](https://github.com/Wbaker7702/sora/security/code-scanning/14)

In general, the fix is to avoid constructing a single shell command string that includes `distPath` and instead invoke the command with separate arguments so that the path is not interpreted by a shell. For `child_process`, that means using `execFileSync` (or `spawnSync`) with an argument array instead of `execSync` with a shell command string.

Concretely, in `src/monitoring/build-monitor.ts` within `measureBuildSize`, replace:

- The import of `execSync` with `execFileSync`.
- The call `execSync(\`du -sh ${distPath}\`, { encoding: 'utf8' })` with `execFileSync('du', ['-sh', distPath], { encoding: 'utf8' })`.

This preserves functionality (still runs `du -sh <path>` and parses its output the same way) but ensures `distPath` is passed as a literal argument, not interpolated into a shell command. The only required changes are the import on line 1 and the command invocation on line 112; no new helpers or additional libraries are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Use a direct process execution API with argument arrays for the build size check to prevent shell interpretation of the output directory path.