### PR TITLE
Potential fix for code scanning alert no. 13: Shell command built from environment values

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -195,8 +195,17 @@ function deployToSnap() {
   const snapFile = snapFiles[0];
   log(`📦 Found snap file: ${snapFile}`, 'cyan');
 
-  // Upload to snap store
-  if (!execCommand(`snapcraft upload dist/${snapFile}`)) {
+  // Upload to snap store without invoking a shell
+  const snapPath = path.join('dist', snapFile);
+  try {
+    log(`\n🔧 Executing: snapcraft upload ${snapPath}`, 'cyan');
+    require('child_process').execFileSync('snapcraft', ['upload', snapPath], {
+      stdio: 'inherit',
+      cwd: process.cwd()
+    });
+  } catch (error) {
+    log(`❌ Command failed: snapcraft upload ${snapPath}`, 'red');
+    log(`Error: ${error.message}`, 'red');
     return false;
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Wbaker7702/sora/security/code-scanning/13](https://github.com/Wbaker7702/sora/security/code-scanning/13)

In general, to fix this vulnerability, avoid building a shell command string that includes untrusted or environment-derived values and then passing it to `exec`/`execSync`. Instead, call the underlying program directly using `spawn`/`spawnSync` or `execFile`/`execFileSync`, providing dynamic parts as separate arguments so they are not interpreted by a shell.

In this file, the best fix is to keep `execCommand` for simple fixed-string commands that do not contain tainted data, but bypass it for the Snap upload where the filename is dynamic. In `deployToSnap`, replace `execCommand(\`snapcraft upload dist/${snapFile}\`)` with a direct call to `execFileSync('snapcraft', ['upload', path.join('dist', snapFile)], ...)`. This invokes `snapcraft` without going through a shell, and passes the filename as a distinct argument, so any special characters in the filename will not be interpreted by a shell. We already import `path` and `child_process.execSync`; we can reuse `execSync` via `require('child_process').execFileSync` instead, or call `require('child_process').execFileSync` inline. Since we are restricted to the shown snippet and existing imports, the minimal change is to use `require('child_process').execFileSync` inside `deployToSnap`, preserve the logging and return semantics, and keep all other behavior identical.

Specifically:
- In `scripts/deploy.js`, within `deployToSnap`, replace the block that calls `execCommand(\`snapcraft upload dist/${snapFile}\`)` with a `try/catch` that:
  - Logs the command being executed (for consistency).
  - Calls `require('child_process').execFileSync('snapcraft', ['upload', path.join('dist', snapFile)], { stdio: 'inherit', cwd: process.cwd() })`.
  - On success, continues as before; on failure, logs the error and returns `false`.
No new top-level imports are strictly required; we can use `require('child_process')` at the call site.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Prevent potential shell injection in Snap uploads by avoiding shell-constructed commands with dynamic filenames.